### PR TITLE
Update EF.Reverse.POCO.ttinclude

### DIFF
--- a/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
+++ b/EntityFramework.Reverse.POCO.Generator/EF.Reverse.POCO.ttinclude
@@ -477,7 +477,7 @@ foreach(var usingStatement in usingsContext.Distinct().OrderBy(x => x)) { #>
 
 <# } #>
     <#= CodeGeneratedAttribute #>
-    public <# if(MakeClassesPartial) { #>partial <# } #>class Fake<#=DbContextName #> : I<#=DbContextName #>
+    public <# if(MakeClassesPartial) { #>partial <# } #>class Fake<#=DbContextName #> : I<#=DbContextInterfaceName #>
     {
 <#
 foreach (Table tbl in from t in tables.Where(t => !t.IsMapping && t.HasPrimaryKey).OrderBy(x => x.NameHumanCase) select t)


### PR DESCRIPTION
Honoring the custom Interface name. That functionality is broken without this change.